### PR TITLE
Issue #71: Migrate CloudWatch plugin to this repository

### DIFF
--- a/cloudwatch/pom.xml
+++ b/cloudwatch/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2017 Decipher Technology Studios LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.deciphernow</groupId>
+        <artifactId>gm-fabric</artifactId>
+        <version>0.2.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>gm-fabric-cloudwatch</artifactId>
+
+    <name>Microservice framework [CloudWatch Plugin]</name>
+    <description>This project provides a plugin for pushing metrics to AWS CloudWatch.</description>
+
+    <properties>
+        <version.cloudwatch>1.11.182</version.cloudwatch>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${version.logback}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-cloudwatch</artifactId>
+            <version>${version.cloudwatch}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.deciphernow</groupId>
+            <artifactId>gm-fabric-core</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.twitter</groupId>
+            <artifactId>util-app_${version.scala.major}</artifactId>
+            <version>${version.twitter.util}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.twitter</groupId>
+            <artifactId>util-core_${version.scala.major}</artifactId>
+            <version>${version.twitter.util}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/cloudwatch/src/main/resources/META-INF/services/com.twitter.finagle.HttpMuxHandler
+++ b/cloudwatch/src/main/resources/META-INF/services/com.twitter.finagle.HttpMuxHandler
@@ -1,0 +1,1 @@
+com.deciphernow.fabric.cloudwatch.StatusHttpHandler

--- a/cloudwatch/src/main/scala/com/deciphernow/fabric/cloudwatch/Config.scala
+++ b/cloudwatch/src/main/scala/com/deciphernow/fabric/cloudwatch/Config.scala
@@ -1,0 +1,60 @@
+package com.deciphernow.fabric.cloudwatch
+
+/*
+    Copyright 2017 Decipher Technology Studios LLC
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+import java.util.Date
+
+import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, StandardUnit}
+import com.twitter.app.GlobalFlag
+
+object period extends GlobalFlag[Int](300, "The publish period in seconds. Metrics will be published every <period> seconds.")
+
+object region extends GlobalFlag[String]("us-east-1", "The AWS region to send metrics to.")
+
+object namespace extends GlobalFlag[String]("microservice", "The namespace that metrics are published under.")
+
+object metricNames extends GlobalFlag[Set[String]](Set("process/cpu/percent","process/memory/mb","process/memory/percent","srv/load","srv/request_latency_ms.p90"), "The names of the metrics to publish.")
+
+object pidName extends GlobalFlag[String]("wrapper.java.pid", "The name of the java process running on the instance")
+
+object serviceName extends GlobalFlag[String]("not-configured","Should bee the name of the service metrics are being captured.")
+
+/**
+  * Represents a metric: key, value, date
+  * wraps a convenience function to convert the simple metric to a MetricDatum
+  * @param key
+  * @param value
+  * @param now
+  */
+case class Metric(key: String, value: Double, now: Date) {
+
+  def asDatum: MetricDatum = new MetricDatum()
+    .withMetricName(key)
+    .withUnit(StandardUnit.None)
+    .withTimestamp(now)
+    .withValue(value)
+    .withDimensions(
+      new Dimension()
+        .withName("Service Name")
+        .withValue(serviceName())
+    )
+}
+// Alternative means of creating a metric
+object Metric {
+  def apply(tuple: (String, Number), date: Date) = new Metric(tuple._1, tuple._2.doubleValue(), date)
+  def apply(key: String, value: String, date: Date) = new Metric(key, value.toDouble, date)
+}

--- a/cloudwatch/src/main/scala/com/deciphernow/fabric/cloudwatch/MetricsPublisher.scala
+++ b/cloudwatch/src/main/scala/com/deciphernow/fabric/cloudwatch/MetricsPublisher.scala
@@ -1,0 +1,179 @@
+package com.deciphernow.fabric.cloudwatch
+
+/*
+    Copyright 2017 Decipher Technology Studios LLC
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
+import com.amazonaws.services.cloudwatch.model.{MetricDatum, PutMetricDataRequest}
+import com.twitter.finagle.stats.MetricsStatsReceiver
+import java.lang.management.ManagementFactory
+import java.util.Date
+import java.util.concurrent.{Executors, TimeUnit}
+import javax.management.ObjectName
+
+import org.slf4j.LoggerFactory
+
+import scala.sys.process._
+import scala.util.parsing.json.JSONObject
+import scala.collection.JavaConverters._
+
+trait Logging {
+  protected val logger = LoggerFactory.getLogger(classOf[MetricsPublisher])
+}
+
+trait FlagInitializationScheduler extends Logging {
+  this: MetricsPublisher =>
+
+  private val checkingFlagInitializationScheduler = Executors.newScheduledThreadPool(1)
+  private val checkFlagInitialization = new Runnable() {
+    def run() = {
+      if (metricNames().isEmpty) {
+        logger.warn("There are no metrics configured to be published! (did you forget to configure metricsNames?)")
+      } else {
+        checkingFlagInitializationScheduler.shutdown()
+        logger.info(s"Publishing metrics every: ${period()} seconds")
+        publishingMetricsScheduler.scheduleAtFixedRate(publishMetrics, 0, period(), TimeUnit.SECONDS)
+      }
+    }
+  }
+  checkingFlagInitializationScheduler.scheduleAtFixedRate(checkFlagInitialization, 5, 5, TimeUnit.SECONDS)
+
+  private[cloudwatch] val publishingMetricsScheduler = Executors.newScheduledThreadPool(1)
+  private[cloudwatch] val publishMetrics = new Runnable() {
+    def run() = {
+      try {
+        logger.debug(
+          s"""Publishing metrics to CloudWatch:
+             |Region: ${region()}
+             |Namespace: ${namespace()}
+             |Period: ${period()}
+             |Metric Names: ${metricNames()}
+             |Service Name: ${serviceName()}
+             |Pid: ${pidName()}
+           """.stripMargin)
+
+        val client = createClient
+
+        val requestData = metricNames().flatMap { key =>
+          makeMetricDatum(key)
+        }.toSeq
+
+        val request = new PutMetricDataRequest()
+          .withNamespace(namespace())
+          .withMetricData(requestData.asJavaCollection)
+
+        client.putMetricData(request)
+        lastPublished = new Date()
+      } catch {
+        case e: Exception => logger.error("An exception occurred while publishing metrics:", e)
+      }
+    }
+
+  }
+}
+
+class MetricsPublisher extends FlagInitializationScheduler {
+
+  import MetricsPublisher._
+
+  private[cloudwatch] implicit var lastPublished = new Date()
+
+  // get sample metrics from the registry
+  private[cloudwatch] def sample = MetricsStatsReceiver
+    .defaultRegistry
+    .sample
+    .asScala
+    .toMap
+
+  // create a publishing client
+  private[cloudwatch] def createClient = AmazonCloudWatchClientBuilder
+    .standard()
+    .withCredentials(new DefaultAWSCredentialsProviderChain())
+    .withRegion(region())
+    .build()
+
+  private def maybeMetric(key: String): Option[MetricDatum] = sample.find(a => a._1 == key) match {
+    case None => None
+    case Some(d) => Some(Metric(d, lastPublished).asDatum)
+  }
+
+
+  /**
+    * Make the appropriate type of metricdatum
+    * @param key
+    * @return
+    */
+  def makeMetricDatum(key: String): Option[MetricDatum] = key match {
+    case `processCpuPercent` => maybeCpu
+    case `processMemoryKb` => maybeMemory.headOption
+    case `processMemoryPercent` => maybeMemory.lastOption
+    case _ => maybeMetric(key)
+  }
+
+  /**
+    * Provides status function to statushttphandler
+    * @return
+    */
+  def status(): String = JSONObject(Map(
+    "period" -> period(),
+    "namespace" -> namespace(),
+    "metricNames" -> metricNames(),
+    "serviceName" -> serviceName(),
+    "lastPublished" -> lastPublished
+  )).toString
+}
+
+object MetricsPublisher {
+
+  val processCpuPercent = "process/cpu/percent"
+  val processMemoryKb = "process/memory/kb"
+  val processMemoryPercent = "process/memory/percent"
+
+  // return cpu usage if available
+  def maybeCpu(implicit lastPublished: Date): Option[MetricDatum] = ManagementFactory
+    .getPlatformMBeanServer
+    .getAttributes(ObjectName.getInstance("java.lang:type=OperatingSystem"), Array("ProcessCpuLoad"))
+    .asList()
+    .asScala
+    .headOption
+    .map { v => Metric(processCpuPercent, (v.getValue.asInstanceOf[Double] * 1000).toInt / 10.0, lastPublished).asDatum}
+    .filter(a => a.getValue != -1.0)
+
+
+  // obtain memory usage if available
+  def maybeMemory(implicit lastPublished: Date): Seq[MetricDatum] = {
+    // convenience function within the function
+    def md(key: String, value: String) = Metric(key, value.toDouble, lastPublished).asDatum
+
+    try {
+      val pid = sys.props.get(pidName())
+      val lines = Seq("ps", "-p", pid.getOrElse("1000000"), "-o", "rss,%mem", "--no-headers").lineStream
+
+      lines.takeWhile(_ != null).flatMap { line =>
+        val stats = line.trim().split("\\s+")
+        stats.length match {
+          case 2 => Seq(md(processMemoryKb, stats(0)), md(processMemoryPercent, stats(1)))
+          case _ => Seq.empty
+        }
+      }
+    } catch {
+      case _: Exception =>
+        Seq.empty
+    }
+  }
+
+}

--- a/cloudwatch/src/main/scala/com/deciphernow/fabric/cloudwatch/StatusHttpHandler.scala
+++ b/cloudwatch/src/main/scala/com/deciphernow/fabric/cloudwatch/StatusHttpHandler.scala
@@ -1,0 +1,33 @@
+package com.deciphernow.fabric.cloudwatch
+
+/*
+    Copyright 2017 Decipher Technology Studios LLC
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+import com.twitter.finagle.http.{HttpMuxHandler, Request, Response, Status}
+import com.twitter.util.Future
+import com.twitter.io.Buf.Utf8
+
+class StatusHttpHandler extends HttpMuxHandler {
+  val pattern: String = "/admin/metrics/cloudwatch.json"
+  val metricsPublisher = new MetricsPublisher()
+
+  def apply(request: Request): Future[Response] = {
+    val response = Response(request.version, Status.Ok)
+    response.setContentTypeJson()
+    response.content = Utf8.apply(metricsPublisher.status())
+    Future.value(response)
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
 
     <modules>
         <module>core</module>
+        <module>cloudwatch</module>
         <module>archetype</module>
         <module>integration-setup</module>
         <module>integration-verify</module>


### PR DESCRIPTION
This is a straight lift of the cloudwatch plugin into this repository.  Note that as a straight lift I have not modified any of that code, but have some questions.

This implementation is reliant upon the tanuki soft wrapper in order to retrieve the memory usage of the process.  I can't recall why we did not migrate this to using the metrics available from the `Runtime`?  Is it because we cannot get a sense for the total picture on a machine?  If that's the case then we should probably rethink that as it's not truly important.  What we must capture is how close we are to blowing through the max memory allocated to our JVM instance.  As that's the true constraint.  Thoughts?