### PR TITLE
WIP: Example usage of a NameServiceProvider to override DNS behaviors.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,6 +37,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <zookeeper.port>${docker.zookeeper.port}</zookeeper.port>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -46,8 +51,41 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <autoCreateCustomNetworks>true</autoCreateCustomNetworks>
+                    <images>
+                        <image>
+                            <alias>zookeeper-${maven.build.timestamp}</alias>
+                            <name>zookeeper:3.3.6</name>
+                            <run>
+                                <ports>
+                                    <port>${docker.zookeeper.port}:2181</port>
+                                </ports>
+                            </run>
+                        </image>
+                    </images>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>start</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
-
     </build>
 
     <dependencies>

--- a/core/src/main/scala/com/deciphernow/server/GMFNameService.scala
+++ b/core/src/main/scala/com/deciphernow/server/GMFNameService.scala
@@ -1,0 +1,53 @@
+package com.deciphernow.server
+
+/**
+  * Copyright 2017 Decipher Technology Studios LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *     http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+import java.net.{InetAddress, UnknownHostException}
+
+import com.google.common.net.InetAddresses
+
+import sun.net.spi.nameservice.NameService
+
+/**
+  * Provides an implementation of the [[NameService]] interface that prevents DNS lookups for a single IP address.
+  */
+object GMFNameService extends NameService {
+
+  val string = sys.env.getOrElse("GMF_IP_ADDRESS", "0.0.0.0")
+  val address = InetAddresses.forString(string)
+
+  /**
+    * Returns the addresses that resolve for a hostname.
+    *
+    * @param host the hostname
+    * @return the addresses
+    * @throws UnknownHostException if the hostname does not resolve
+    */
+  override def lookupAllHostAddr(host: String): Array[InetAddress] = throw new UnknownHostException(host)
+
+  /**
+    * Returns the hostname that corresponds to an address.
+    *
+    * @param bytes the address
+    * @return the hostname
+    * @throws UnknownHostException if the address does not correspond to a hostname
+    */
+  override def getHostByAddr(bytes: Array[Byte]): String = {
+    if (bytes.sameElements(address.getAddress)) string else throw new UnknownHostException()
+  }
+
+}

--- a/core/src/main/scala/com/deciphernow/server/GMFNameServiceDescriptor.scala
+++ b/core/src/main/scala/com/deciphernow/server/GMFNameServiceDescriptor.scala
@@ -1,0 +1,47 @@
+package com.deciphernow.server
+
+/**
+  * Copyright 2017 Decipher Technology Studios LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *     http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+import sun.net.spi.nameservice.NameService
+import sun.net.spi.nameservice.NameServiceDescriptor
+
+/**
+  * Provides an implementation of the [[NameServiceDescriptor]] class for the [[GMFNameService]].
+  */
+class GMFNameServiceDescriptor extends NameServiceDescriptor {
+  /**
+    * Returns the [[GMFNameService]] object.
+    *
+    * @return the name service
+    */
+  override def createNameService(): NameService = GMFNameService
+
+  /**
+    * Gets the provider type for this descriptor.
+    *
+    * @return the type
+    */
+  override def getType: String = "dns"
+
+  /**
+    * Gets the provider name for this descriptor.
+    *
+    * @return the name
+    */
+  override def getProviderName: String = "gmf"
+
+}

--- a/core/src/test/resources/META-INF/services/sun.net.spi.nameservice.NameServiceDescriptor
+++ b/core/src/test/resources/META-INF/services/sun.net.spi.nameservice.NameServiceDescriptor
@@ -1,0 +1,1 @@
+com.deciphernow.server.GMFNameServiceDescriptor

--- a/core/src/test/scala/com/deciphernow/server/IntSpecGMFAnnouncer.scala
+++ b/core/src/test/scala/com/deciphernow/server/IntSpecGMFAnnouncer.scala
@@ -1,0 +1,76 @@
+package com.deciphernow.server
+
+import java.net.InetAddress
+import java.net.URLClassLoader
+
+import com.google.common.net.InetAddresses
+import com.twitter.app.App
+import org.junit.runner.RunWith
+import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.junit.JUnitRunner
+
+import scala.sys.process.Process
+import scala.util.Random
+
+object IntSpecGMFAnnouncerApp extends App {
+
+  GMFNetworkConfigurationResolver.resolveConfiguration
+
+  def main() = {
+    val port = sys.env.getOrElse("ANNOUNCE_PORT", "0").toInt
+    val scheme = sys.env.getOrElse("ANNOUNCE_SCHEME", "none")
+    GMFAnnouncer.announce(port, scheme)
+    Thread.currentThread.join
+  }
+
+}
+
+@RunWith(classOf[JUnitRunner])
+class IntSpecGMFAnnouncer extends FunSpec with Matchers {
+
+  val jar = ClassLoader.getSystemClassLoader.asInstanceOf[URLClassLoader].getURLs.head.toString
+  val zookeeper = s"localhost:${sys.props.get("zookeeper.port").getOrElse("2181")}"
+
+  def execute(host: String, path: String, scheme: String, port: Int): Process = {
+    Process(
+      Seq(
+        "java",
+        "-cp",
+        jar,
+        s"-Dsun.net.spi.nameservice.provider.1=dns,gmf",
+        s"-Dsun.net.spi.nameservice.provider.2=default",
+        s"-Dcom.deciphernow.announcement.config.service.forward.hostname=${host}",
+        s"-Dcom.deciphernow.server.config.zk.announcementPoint=${path}",
+        s"-Dcom.deciphernow.server.config.zk.zookeeperConnection=${zookeeper}",
+        "com.deciphernow.server.IntSpecGMFAnnouncerApp"
+      ),
+      None,
+      ("ANNOUNCE_PORT", port.toString),
+      ("ANNOUNCE_SCHEME", scheme),
+      ("GMF_IP_ADDRESS", host)
+    ).run
+  }
+
+  describe("Announcer") {
+
+    describe("announce") {
+
+      describe("when provided a string that is an IP address") {
+
+        describe("and the address resolves via DNS") {
+
+          val host = InetAddresses.toAddrString(InetAddress.getByName("www.google.com"))
+          val path = s"/${Random.alphanumeric.take(10).mkString}"
+          val scheme = Random.alphanumeric.take(5).mkString
+          val port = Random.nextInt(65535)
+
+          it("should announce the address") {
+            val process = execute(host, path, scheme, port)
+            Thread.sleep(10000)
+            process.destroy()
+          }
+        }
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
 
         <!-- Testing -->
         <maven.test.runOrder>hourly</maven.test.runOrder>
+        <version.docker.plugin>0.20.1</version.docker.plugin>
         <version.junit>4.12</version.junit>
         <version.mockito>1.9.5</version.mockito>
         <version.surefire.plugin>2.20.1</version.surefire.plugin>
@@ -588,6 +589,29 @@
                                 <escapeString>\</escapeString>
                             </configuration>
                         </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>reserve-network-port</id>
+                            <goals>
+                                <goal>reserve-network-port</goal>
+                            </goals>
+                            <phase>process-resources</phase>
+                            <configuration>
+                                <portNames>
+                                    <portName>docker.zookeeper.port</portName>
+                                </portNames>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>${version.docker.plugin}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
NO NOT MERGE: This is only an example solution for #112 and it is not ready without further discussion.  Note that I do not know that this approach works on OpenJDK and it is likely to break in later releases of Java.

Running `mvn clean verify` and looking at the ZooKeeper docker instance that is spun up you can see that the example service is announcing with it's IP address.  If you remove this line, you will see that it announces with its hostname as per DNS: https://github.com/DecipherNow/gm-fabric-jvm/pull/125/files#diff-badf7d07c842086d1446c5fe29e735b9R50.