### PR TITLE
add impersonation logic

### DIFF
--- a/core/src/main/scala/com/deciphernow/server/security/ImpersonationUtil.scala
+++ b/core/src/main/scala/com/deciphernow/server/security/ImpersonationUtil.scala
@@ -1,0 +1,51 @@
+package com.deciphernow.server.security
+
+import java.security.cert.X509Certificate
+
+object ImpersonationUtil {
+  private val dnHelper = new DNHelper
+
+  class Caller(
+                // distinguishedName is the unique identity of a user
+                val distinguishedName: String,
+                // userDistinguishedName holds the value passed in header USER_DN
+                val userDistinguishedName: String,
+                // externalSystemDistinguishedName holds the value passed in header EXTERNAL_SYS_DN
+                val externalSystemDistinguishedName: String,
+                // commonName is the CN value part of the DistinguishedName
+                //val commonName: String
+              )
+
+  /**
+   * getCaller creates a description of the (possibly impersonated) identity of the initiator of an incoming request.
+   *
+   * An important assumption is that there exists a trustworthy, TLS-terminating proxy between the replying service
+   * and the application making the request.
+   *
+   * The proxy is expected to provide two headers:
+   *
+   * USER_DN
+   *   The effective (possibly impersonated) Distinguished Name of requesting application
+   * EXTERNAL_SYS_DN
+   *   The Distinguished Name taken from the client certificate
+   * 
+   * An x509 certificate can be provided to use as a fallback when a USER_DN header is not present, in which case the DN
+   * from the cert will be used. This should only be necessary in the unlikely scenario where you need to allow an
+   * application to bypass the trusted proxy and establish a direct TLS connection to your service.
+  */
+  def getCaller(userDN: String, externalSysDN: String, cert: X509Certificate): Caller = {
+    var distinguishedName = userDN
+    if (userDN != "") {
+      distinguishedName = userDN
+    } else if (cert != null) {
+      distinguishedName = cert.getSubjectX500Principal().getName()
+    }
+    distinguishedName = dnHelper.normalizeDistinguishedName(distinguishedName)
+
+    return new Caller(
+      distinguishedName,
+      userDN,
+      externalSysDN
+    )
+  }
+}


### PR DESCRIPTION
This provides a unified mechanism for determining the effective identity
of a calling application (the logic was ported from gm-fabric-go).

The idea is that a service can use USER_DN and EXTERNAL_SYS_DN headers
as supplied by a trusted proxy, and as a fallback it can pull the DN from the
peers cert (assuming a TLS connection with a provided client cert).

---

/cc @ghershfield 

I need to tie this in as some sort of filter or service factory. Rather than modifying any existing classes, I suppose I could create something similar to the existing [`ClientCertificateServiceFactory`](https://github.com/DecipherNow/gm-fabric-jvm/blob/3e5a4d56224e2e7db36eae353ecd77aa9ea88520/core/src/main/scala/com/deciphernow/server/security/ClientCertificateServiceFactory.scala), only it would use this `ImpersonationUtil` instead of pulling the DN straight from the client cert. Does that seem reasonable?

My Scala is extremely rusty, so any advice on how to make this more idiomatic would be appreciated.