### PR TITLE
Add an IndividualRequestTimeoutException Mapper to HttpRouter

### DIFF
--- a/core/src/main/scala/com/deciphernow/server/rest/GMFabricRestServer.scala
+++ b/core/src/main/scala/com/deciphernow/server/rest/GMFabricRestServer.scala
@@ -170,6 +170,7 @@ class GMFabricRestServer(filters: Seq[Filter[FinagleRequest, FinagleResponse,Fin
     }
 
     router.exceptionMapper[FailFastExceptionMapper]
+    router.exceptionMapper[IndividualRequestTimeoutExceptionMapper]
   }
 
   lazy val decrypter : Decryptor = DecryptorManager.getInstance

--- a/core/src/main/scala/com/deciphernow/server/rest/IndividualRequestTimeoutExceptionMapper.scala
+++ b/core/src/main/scala/com/deciphernow/server/rest/IndividualRequestTimeoutExceptionMapper.scala
@@ -1,0 +1,15 @@
+package com.deciphernow.server.rest
+
+import com.twitter.finagle.{IndividualRequestTimeoutException}
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finatra.http.exceptions.ExceptionMapper
+import com.twitter.finatra.http.response.ResponseBuilder
+import javax.inject.Inject
+
+class IndividualRequestTimeoutExceptionMapper @Inject()(response: ResponseBuilder) extends ExceptionMapper[IndividualRequestTimeoutException] {
+
+  override def toResponse(request: Request, throwable: IndividualRequestTimeoutException): Response = {
+    response.status(504).body(s"Server is not able to get a response in time: ${throwable.getMessage}")
+  }
+
+}


### PR DESCRIPTION
Currently, a project that has `gm-fabric-jvm` as a dependency can create a new instance of the `GMFabricRestServer` class by passing `Seq` of filters and controllers, but not mappers. The `GMFabricRestServer` currently adds only one custom ExceptionMapper (`FailFastExceptionMapper`) to the `GMFabricRestServer`'s `HttpRouter` method. As a result, in a Rest Controller that relies on the `GMFabricRestServer`, when a request timeout occurs, a generic `500 Internal Server Error` is thrown. This PR is a minor update to the `configureHttp` method in the `GMFabricRestServer` Scala class. The update adds an `IndividualRequestTimeoutException` Mapper to the `HttpRouter` to handle a timeout exception and return a more specific `504 Gateway Timeout` to the user.