### PR TITLE
Add a new modules parameter to GMFabricRestServer to pass in a list o…

### DIFF
--- a/core/src/main/scala/com/deciphernow/server/GMFabricServer.scala
+++ b/core/src/main/scala/com/deciphernow/server/GMFabricServer.scala
@@ -83,7 +83,7 @@ abstract class GMFabricServer extends App {
     rest match {
       case Some(_) =>
         log.ifDebug("creating restful server.")
-        restServer = Option(new GMFabricRestServer(rest.get.filters, rest.get.controllers))
+        restServer = Option(new GMFabricRestServer(rest.get.filters, rest.get.controllers, rest.get.modules))
         if (announceAdmin) {
           GMFAnnouncer.announce(GMFNetworkConfigurationResolver.getAnnounceAdminPort,"admin")
         }

--- a/core/src/main/scala/com/deciphernow/server/RestServer.scala
+++ b/core/src/main/scala/com/deciphernow/server/RestServer.scala
@@ -20,14 +20,16 @@ package com.deciphernow.server
 import com.twitter.finagle.Filter
 import com.twitter.finagle.http.{Request => FinagleRequest, Response => FinagleResponse}
 import com.twitter.finatra.http.Controller
+import com.twitter.inject.TwitterModule
 
 /**
   *
   * @param filters
   * @param controllers
+  * @param modules
   */
-case class RestServer(filters: Seq[Filter[FinagleRequest, FinagleResponse,FinagleRequest, FinagleResponse]],controllers: Seq[Controller]) {
-  def this(controllers: Seq[Controller]) = this(Nil,controllers)
-  def this(filters: Seq[Filter[FinagleRequest, FinagleResponse,FinagleRequest, FinagleResponse]],controller: Controller) = this(filters,controller :: Nil)
+case class RestServer(filters: Seq[Filter[FinagleRequest, FinagleResponse,FinagleRequest, FinagleResponse]],controllers: Seq[Controller], modules: Seq[TwitterModule] = Nil) {
+  def this(controllers: Seq[Controller]) = this(Nil,controllers, Nil)
+  def this(filters: Seq[Filter[FinagleRequest, FinagleResponse,FinagleRequest, FinagleResponse]],controller: Controller) = this(filters,controller :: Nil, Nil)
   def this(controller: Controller) = this(controller :: Nil)
 }

--- a/core/src/main/scala/com/deciphernow/server/rest/GMFabricRestServer.scala
+++ b/core/src/main/scala/com/deciphernow/server/rest/GMFabricRestServer.scala
@@ -26,6 +26,7 @@ import com.twitter.finagle.{Filter, Http}
 import com.twitter.finatra.http.filters.{AccessLoggingFilter, ExceptionMappingFilter, StatsFilter}
 import com.twitter.finatra.http.routing.HttpRouter
 import com.twitter.finatra.http.{Controller, HttpServer}
+import com.twitter.inject.TwitterModule
 import com.twitter.logging.Logger
 import com.twitter.util.StorageUnit
 
@@ -38,7 +39,8 @@ import com.twitter.util.StorageUnit
   * @param filters
   * @param controllers
   */
-class GMFabricRestServer(filters: Seq[Filter[FinagleRequest, FinagleResponse,FinagleRequest, FinagleResponse]], controllers: Seq[Controller])
+class GMFabricRestServer(filters: Seq[Filter[FinagleRequest, FinagleResponse,FinagleRequest, FinagleResponse]], controllers: Seq[Controller],
+                         customModules: Seq[TwitterModule])
   extends HttpServer {
 
   lazy override val log = Logger.get(getClass)
@@ -125,6 +127,8 @@ class GMFabricRestServer(filters: Seq[Filter[FinagleRequest, FinagleResponse,Fin
     ))
   }
 
+  override val modules = customModules
+
   /**
     *
     * @param router
@@ -169,8 +173,10 @@ class GMFabricRestServer(filters: Seq[Filter[FinagleRequest, FinagleResponse,Fin
       log.ifInfo("There are no controllers to add to the router thus no capabilities for this service.")
     }
 
-    router.exceptionMapper[FailFastExceptionMapper]
-    router.exceptionMapper[IndividualRequestTimeoutExceptionMapper]
+    if(modules==Nil) {
+      router.exceptionMapper[FailFastExceptionMapper]
+      router.exceptionMapper[IndividualRequestTimeoutExceptionMapper]
+    }
   }
 
   lazy val decrypter : Decryptor = DecryptorManager.getInstance


### PR DESCRIPTION
Update adds an optional paramter of a `Seq` of `TwitterModules` to the `GMFabricRestServer` construction signature. This enables the user to pass in an ExceptionMapperModule like the below, which registers all custom `ExceptionMappers` to an `ExceptionManager`

```
class CustomExceptionMapperModule extends TwitterModule {
  override def singletonStartup(injector: Injector): Unit = {
    val manager = injector.instance[ExceptionManager]
    manager.add[SomeExceptionMapper]
    manager.add[DifferentExceptionMapper]
  }
}
```

Then, the user instantiates an instance of the `GMFabricRestServer` by passing the `CustomExceptionMapperModule` (optional), which is then registered to the Server by overriding the `modules` method with the custom modules. 
```
override val modules = customModules
``` 
The PR addresses [#169](https://github.com/DecipherNow/gm-fabric-jvm/issues/169)